### PR TITLE
Web: add ratelimting on requests to prevent misuse

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -20,15 +20,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web:2.6.1'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'org.projectlombok:lombok:1.18.22'
-    implementation 'org.liquibase:liquibase-core:4.6.1'
+    implementation 'org.liquibase:liquibase-core:4.6.2'
     implementation 'org.mapstruct:mapstruct:1.4.2.Final'
-    implementation 'org.springdoc:springdoc-openapi-ui:1.6.1'
+    implementation 'org.springdoc:springdoc-openapi-ui:1.6.2'
+    implementation 'com.github.vladimir-bukhtoyarov:bucket4j-core:7.0.0'
 
     runtimeOnly 'mysql:mysql-connector-java:8.0.26'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.6.1'
     testImplementation 'org.springframework.security:spring-security-test:5.5.1'
-    testImplementation 'org.mockito:mockito-core:4.1.0'
+    testImplementation 'org.mockito:mockito-core:4.2.0'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.22'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'

--- a/backend/src/main/java/com/ksonni/footballdb/config/AppConfig.java
+++ b/backend/src/main/java/com/ksonni/footballdb/config/AppConfig.java
@@ -6,6 +6,8 @@ import com.ksonni.footballdb.players.domain.Player;
 import com.ksonni.footballdb.players.services.PlayerQueryParser;
 import com.ksonni.footballdb.queryparser.DefaultQueryParser;
 import com.ksonni.footballdb.queryparser.QueryParser;
+import com.ksonni.footballdb.ratelimiting.IPRateLimitingService;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
 import com.ksonni.footballdb.users.domain.User;
 import com.ksonni.footballdb.users.services.AuthService;
 import com.ksonni.footballdb.users.services.DefaultAuthService;
@@ -17,14 +19,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.core.GrantedAuthorityDefaults;
+
+import java.time.Duration;
 
 /**
  * Supplies beans required by the app.
  */
 @Configuration
 @RequiredArgsConstructor
+@EnableScheduling
 public class AppConfig {
+
+    private static final int MAX_REQUESTS_PER_MIN = 60;
 
     private final BuildProperties buildProperties;
 
@@ -98,6 +106,16 @@ public class AppConfig {
         return new OpenAPI().components(new Components())
                 .info(new Info().title("Football DB API")
                         .version(buildProperties.getVersion()));
+    }
+
+    /**
+     * Returns a RateLimitingService.
+     *
+     * @return RateLimitingService
+     */
+    @Bean
+    public RateLimitingService rateLimitingService() {
+        return new IPRateLimitingService(MAX_REQUESTS_PER_MIN, Duration.ofMinutes(1));
     }
 
 }

--- a/backend/src/main/java/com/ksonni/footballdb/config/RoutesConfig.java
+++ b/backend/src/main/java/com/ksonni/footballdb/config/RoutesConfig.java
@@ -127,7 +127,7 @@ public final class RoutesConfig {
         /**
          * Open API docs in JSON format.
          */
-        public static final String JSON = "/v3/api-docs";
+        public static final String JSON = "/v3/api-docs/**";
         /**
          * Open API docs in YAML format.
          */

--- a/backend/src/main/java/com/ksonni/footballdb/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/ksonni/footballdb/config/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.ksonni.footballdb.config;
 
+import com.ksonni.footballdb.ratelimiting.RateLimitingInterceptor;
 import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +14,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -31,6 +33,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter implements W
     private static final int HTTPS_PORT = 443;
 
     private final UserDetailsService userDetailsService;
+    private final RateLimitingInterceptor rateLimitInterceptor;
 
     @Override
     protected void configure(final HttpSecurity security) throws Exception {
@@ -71,6 +74,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter implements W
         for (var route : corsRoutes) {
             registry.addMapping(route.getPattern()).allowedMethods(route.getMethod().name());
         }
+    }
+
+    @Override
+    public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(rateLimitInterceptor);
     }
 
     private HttpSecurity configureUnauthenticatedRoutes(final HttpSecurity http) throws Exception {

--- a/backend/src/main/java/com/ksonni/footballdb/queryparser/DefaultQueryParser.java
+++ b/backend/src/main/java/com/ksonni/footballdb/queryparser/DefaultQueryParser.java
@@ -29,11 +29,11 @@ public class DefaultQueryParser<T> implements QueryParser<T> {
     /**
      * Max number of results allowed per page.
      */
-    public static final int MAX_PAGE_SIZE = 1000;
+    public static final int MAX_PAGE_SIZE = 100;
     /**
      * Default number of results per page.
      */
-    public static final int DEFAULT_PAGE_SIZE = 100;
+    public static final int DEFAULT_PAGE_SIZE = 25;
 
     private static final String PAGE_SIZE_KEY = "limit";
     private static final String PAGE_KEY = "page";

--- a/backend/src/main/java/com/ksonni/footballdb/ratelimiting/IPRateLimitingService.java
+++ b/backend/src/main/java/com/ksonni/footballdb/ratelimiting/IPRateLimitingService.java
@@ -1,0 +1,87 @@
+package com.ksonni.footballdb.ratelimiting;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Rate limits requests based on the IP address of the source using the token bucket algorithm.
+ */
+@Slf4j
+public class IPRateLimitingService implements RateLimitingService {
+
+    private final int maxRequests;
+    private final Duration duration;
+
+    private final Map<String, Bucket> cache = new ConcurrentHashMap<>();
+
+    /**
+     * Constructs a service that limits requests based on the IP address of the source.
+     *
+     * @param maxRequests Max number of requests to allow in the specified duration
+     * @param duration    Duration in which to enforce the maxRequests limit
+     */
+    public IPRateLimitingService(final int maxRequests, final Duration duration) {
+        this.maxRequests = maxRequests;
+        this.duration = duration;
+    }
+
+    @Override
+    public RateLimitingResult evaluateRequest(final HttpServletRequest request) {
+        final String ip = request.getRemoteAddr();
+        if (ip == null || ip.isBlank()) {
+            return RateLimitingResult.reject("Unable to determine IP address");
+        }
+
+        final Bucket bucket = cache.computeIfAbsent(ip, this::makeBucket);
+        final boolean consumed = bucket.tryConsume(1);
+
+        return consumed ? RateLimitingResult.accept()
+                : RateLimitingResult.reject(constructLimitExceededMessage());
+    }
+
+    /**
+     * Clears buckets that have reached max number of tokens, from the cache.
+     * This is run periodically by the service to free up memory.
+     *
+     * @return The number of buckets that were cleared
+     */
+    @Scheduled(fixedRate = 1, timeUnit = TimeUnit.DAYS)
+    public int clearFilledBuckets() {
+        final Set<String> keys = cache.keySet();
+        int bucketsRemoved = 0;
+
+        log.info("Running cache clean up");
+        for (String key : keys) {
+            final Bucket bucket = cache.get(key);
+            if (bucket.getAvailableTokens() == maxRequests) {
+                cache.remove(key);
+                bucketsRemoved++;
+            }
+        }
+        log.info("Removed {} buckets from the cache", bucketsRemoved);
+
+        return bucketsRemoved;
+    }
+
+    private Bucket makeBucket(final String ipAddress) {
+        final Refill refillPolicy = Refill.intervally(maxRequests, duration);
+        final Bandwidth limit = Bandwidth.classic(maxRequests, refillPolicy);
+        return Bucket.builder().addLimit(limit).build();
+    }
+
+    private String constructLimitExceededMessage() {
+        return String.format("Request limit reached. Try again in about %s",
+                duration.toString());
+    }
+
+}

--- a/backend/src/main/java/com/ksonni/footballdb/ratelimiting/RateLimitingInterceptor.java
+++ b/backend/src/main/java/com/ksonni/footballdb/ratelimiting/RateLimitingInterceptor.java
@@ -1,0 +1,31 @@
+package com.ksonni.footballdb.ratelimiting;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RateLimitingInterceptor implements HandlerInterceptor {
+
+    private final RateLimitingService rateLimitingService;
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
+                             final Object handler) throws IOException {
+        final RateLimitingResult result = rateLimitingService.evaluateRequest(request);
+        if (!result.isAcceptable()) {
+            response.sendError(HttpStatus.TOO_MANY_REQUESTS.value(), result.getRejectionReason());
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/backend/src/main/java/com/ksonni/footballdb/ratelimiting/RateLimitingResult.java
+++ b/backend/src/main/java/com/ksonni/footballdb/ratelimiting/RateLimitingResult.java
@@ -1,0 +1,32 @@
+package com.ksonni.footballdb.ratelimiting;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RateLimitingResult {
+
+    private final boolean acceptable;
+    private final String rejectionReason;
+
+    /**
+     * Constructs a result indicating the request can be accepted.
+     *
+     * @return Acceptable result
+     */
+    public static RateLimitingResult accept() {
+        return new RateLimitingResult(true, null);
+    }
+
+    /**
+     * Constructs a result indicating the request can not be accepted.
+     *
+     * @param reason Message explaining why the request could not be accepted
+     * @return Acceptable result
+     */
+    public static RateLimitingResult reject(final String reason) {
+        return new RateLimitingResult(false, reason);
+    }
+
+}

--- a/backend/src/main/java/com/ksonni/footballdb/ratelimiting/RateLimitingService.java
+++ b/backend/src/main/java/com/ksonni/footballdb/ratelimiting/RateLimitingService.java
@@ -1,0 +1,15 @@
+package com.ksonni.footballdb.ratelimiting;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface RateLimitingService {
+
+    /**
+     * Determines whether a request can be accepted using a rate limiting strategy.
+     *
+     * @param request HTTP request
+     * @return Result indicating if a request can be accepted
+     */
+    RateLimitingResult evaluateRequest(HttpServletRequest request);
+
+}

--- a/backend/src/main/java/com/ksonni/footballdb/ratelimiting/package-info.java
+++ b/backend/src/main/java/com/ksonni/footballdb/ratelimiting/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Classes that apply rate limiting on in incoming requests.
+ */
+package com.ksonni.footballdb.ratelimiting;

--- a/backend/src/test/java/com/ksonni/footballdb/clubs/ClubsControllerTests.java
+++ b/backend/src/test/java/com/ksonni/footballdb/clubs/ClubsControllerTests.java
@@ -12,9 +12,11 @@ import com.ksonni.footballdb.leagues.services.LeaguesRepository;
 import com.ksonni.footballdb.queryparser.Query;
 import com.ksonni.footballdb.queryparser.QueryParseException;
 import com.ksonni.footballdb.queryparser.QueryParser;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
 import com.ksonni.footballdb.users.domain.Permission;
 import com.ksonni.footballdb.utils.MathUtils;
 import com.ksonni.footballdb.utils.MockMvcUtils;
+import com.ksonni.footballdb.utils.MockUtils;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.AfterEach;
@@ -59,6 +61,8 @@ class ClubsControllerTests {
     private QueryParser<Club> queryParser;
     @MockBean
     private UserDetailsService userDetailsService;
+    @MockBean
+    private RateLimitingService rateLimitingService;
     @Autowired
     private MockMvc mockMvc;
     private List<Club> clubs;
@@ -87,11 +91,7 @@ class ClubsControllerTests {
                 .leagueId("LeagueId")
                 .build();
         validPatchRequest = PatchClubRequest.builder().name("Some other club").build();
-    }
-
-    @AfterEach
-    void tearDown() {
-        Mockito.reset(clubsRepository, queryParser, userDetailsService, leaguesRepository, mapper);
+        MockUtils.disableRateLimiting(rateLimitingService);
     }
 
     @Test
@@ -275,6 +275,19 @@ class ClubsControllerTests {
                 .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
+    @Test
+    void handlesRateLimitsReached() throws Exception {
+        MockUtils.mockRateLimitReached(rateLimitingService);
+        mockMvc.perform(utils.get(RoutesConfig.Clubs.PATH))
+                .andExpect(MockMvcResultMatchers.status().isTooManyRequests());
+    }
+
+    @AfterEach
+    void tearDown() {
+        Mockito.reset(clubsRepository, queryParser, userDetailsService, leaguesRepository,
+                mapper, rateLimitingService);
+    }
+
     @WithMockUser(roles = {
             Permission.Code.MANAGE_CLUBS,
             Permission.Code.MANAGE_PLAYERS
@@ -282,6 +295,5 @@ class ClubsControllerTests {
     @Retention(RetentionPolicy.RUNTIME)
     private @interface DeletePermissions {
     }
-
 
 }

--- a/backend/src/test/java/com/ksonni/footballdb/leagues/LeaguesControllerTests.java
+++ b/backend/src/test/java/com/ksonni/footballdb/leagues/LeaguesControllerTests.java
@@ -10,8 +10,10 @@ import com.ksonni.footballdb.leagues.services.LeaguesRepository;
 import com.ksonni.footballdb.queryparser.Query;
 import com.ksonni.footballdb.queryparser.QueryParseException;
 import com.ksonni.footballdb.queryparser.QueryParser;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
 import com.ksonni.footballdb.users.domain.Permission;
 import com.ksonni.footballdb.utils.MockMvcUtils;
+import com.ksonni.footballdb.utils.MockUtils;
 import com.ksonni.footballdb.utils.TestStringUtils;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
@@ -52,6 +54,8 @@ class LeaguesControllerTests {
     private UserDetailsService userDetailsService;
     @MockBean
     private LeaguesMapper mapper;
+    @MockBean
+    private RateLimitingService rateLimitingService;
     @Autowired
     private MockMvc mockMvc;
     private List<League> leagues;
@@ -78,11 +82,7 @@ class LeaguesControllerTests {
 
         validRegisterRequest = RegisterLeagueRequest.builder().name("League").build();
         validPatchRequest = PatchLeagueRequest.builder().name("Some other league").build();
-    }
-
-    @AfterEach
-    void tearDown() {
-        Mockito.reset(leaguesRepository, queryParser, userDetailsService, mapper);
+        MockUtils.disableRateLimiting(rateLimitingService);
     }
 
     @Test
@@ -206,6 +206,19 @@ class LeaguesControllerTests {
                 .willReturn(Optional.empty());
         mockMvc.perform(utils.delete(LEAGUES_PATH))
                 .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    void handlesRateLimitsReached() throws Exception {
+        MockUtils.mockRateLimitReached(rateLimitingService);
+        mockMvc.perform(utils.get(RoutesConfig.Leagues.PATH))
+                .andExpect(MockMvcResultMatchers.status().isTooManyRequests());
+    }
+
+    @AfterEach
+    void tearDown() {
+        Mockito.reset(leaguesRepository, queryParser, userDetailsService,
+                mapper, rateLimitingService);
     }
 
     @WithMockUser(roles = {

--- a/backend/src/test/java/com/ksonni/footballdb/players/PlayersControllerTests.java
+++ b/backend/src/test/java/com/ksonni/footballdb/players/PlayersControllerTests.java
@@ -16,9 +16,11 @@ import com.ksonni.footballdb.players.services.PlayersRepository;
 import com.ksonni.footballdb.queryparser.Query;
 import com.ksonni.footballdb.queryparser.QueryParseException;
 import com.ksonni.footballdb.queryparser.QueryParser;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
 import com.ksonni.footballdb.users.domain.Permission;
 import com.ksonni.footballdb.utils.MathUtils;
 import com.ksonni.footballdb.utils.MockMvcUtils;
+import com.ksonni.footballdb.utils.MockUtils;
 import com.ksonni.footballdb.utils.TestStringUtils;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
@@ -63,6 +65,8 @@ class PlayersControllerTests {
     private PlayersMapper mapper;
     @MockBean
     private ClubsRepository clubsRepository;
+    @MockBean
+    private RateLimitingService rateLimitingService;
     @Autowired
     private MockMvc mockMvc;
     private List<Player> players;
@@ -99,12 +103,7 @@ class PlayersControllerTests {
                 .squadNumber(RANDOM_SQUAD_NUM).position(Position.CENTER_FORWARD).countryCode("GB");
         validRegisterRequest = registerRequestSupplier.get().build();
         validPatchRequest = PatchPlayerRequest.builder().fullName("Some other player").build();
-    }
-
-    @AfterEach
-    void tearDown() {
-        Mockito.reset(playersRepository, queryParser, userDetailsService,
-                clubsRepository, mapper);
+        MockUtils.disableRateLimiting(rateLimitingService);
     }
 
     @Test
@@ -322,6 +321,19 @@ class PlayersControllerTests {
         BDDMockito.given(playersRepository.findById(PLAYER_ID)).willReturn(Optional.empty());
         mockMvc.perform(utils.delete(PLAYER_PATH))
                 .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    void handlesRateLimitsReached() throws Exception {
+        MockUtils.mockRateLimitReached(rateLimitingService);
+        mockMvc.perform(utils.get(RoutesConfig.Players.PATH))
+                .andExpect(MockMvcResultMatchers.status().isTooManyRequests());
+    }
+
+    @AfterEach
+    void tearDown() {
+        Mockito.reset(playersRepository, queryParser, userDetailsService,
+                clubsRepository, mapper, rateLimitingService);
     }
 
 }

--- a/backend/src/test/java/com/ksonni/footballdb/ratelimiting/IPRateLimitingServiceTests.java
+++ b/backend/src/test/java/com/ksonni/footballdb/ratelimiting/IPRateLimitingServiceTests.java
@@ -1,0 +1,76 @@
+package com.ksonni.footballdb.ratelimiting;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.servlet.http.HttpServletRequest;
+import java.time.Duration;
+
+@ExtendWith(MockitoExtension.class)
+public class IPRateLimitingServiceTests {
+
+    private static final int REQUEST_LIMIT = 5;
+    private static final Duration DURATION = Duration.ofMillis(200);
+
+    @Mock
+    private HttpServletRequest request;
+    private IPRateLimitingService service;
+
+    @BeforeEach
+    void setup() {
+        service = new IPRateLimitingService(REQUEST_LIMIT, DURATION);
+        BDDMockito.given(request.getRemoteAddr()).willReturn("0.0.0.0");
+    }
+
+    @Test
+    void evaluateResultRejectsAfterMaxRequestsReached() {
+        performMaxRequests();
+
+        final RateLimitingResult result = service.evaluateRequest(request);
+        Assertions.assertFalse(result.isAcceptable());
+    }
+
+    @Test
+    void evaluateResultAcceptsMoreRequestsAfterTheDurationHasElapsed() throws InterruptedException {
+        performMaxRequests();
+
+        Thread.sleep(DURATION.toMillis());
+
+        final RateLimitingResult result = service.evaluateRequest(request);
+        Assertions.assertTrue(result.isAcceptable());
+    }
+
+    @Test
+    void clearFilledBucketsOnlyClearsFilledBuckets() throws InterruptedException {
+        performMaxRequests();
+
+        final int cleared = service.clearFilledBuckets();
+        Assertions.assertEquals(0, cleared);
+
+        Thread.sleep(DURATION.toMillis());
+
+        final int clearedAfterDuration = service.clearFilledBuckets();
+        Assertions.assertEquals(1, clearedAfterDuration);
+    }
+
+    @AfterEach
+    void tearDown() {
+        Mockito.reset(request);
+    }
+
+    // There is an assumption that this can complete within the max requests duration
+    private void performMaxRequests() {
+        for (int i = 0; i < REQUEST_LIMIT; i++) {
+            final RateLimitingResult result = service.evaluateRequest(request);
+            Assertions.assertTrue(result.isAcceptable());
+        }
+    }
+
+}

--- a/backend/src/test/java/com/ksonni/footballdb/ratelimiting/package-info.java
+++ b/backend/src/test/java/com/ksonni/footballdb/ratelimiting/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Tests related to the rate limiting service.
+ */
+package com.ksonni.footballdb.ratelimiting;

--- a/backend/src/test/java/com/ksonni/footballdb/users/AuthControllerTests.java
+++ b/backend/src/test/java/com/ksonni/footballdb/users/AuthControllerTests.java
@@ -1,6 +1,7 @@
 package com.ksonni.footballdb.users;
 
 import com.ksonni.footballdb.config.RoutesConfig;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
 import com.ksonni.footballdb.users.domain.Role;
 import com.ksonni.footballdb.users.domain.User;
 import com.ksonni.footballdb.users.dto.LoginRequest;
@@ -10,9 +11,11 @@ import com.ksonni.footballdb.users.services.AuthService;
 import com.ksonni.footballdb.users.services.UsersMapper;
 import com.ksonni.footballdb.users.services.UsersRepository;
 import com.ksonni.footballdb.utils.MockMvcUtils;
+import com.ksonni.footballdb.utils.MockUtils;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
@@ -56,8 +59,15 @@ class AuthControllerTests {
     private UserDetailsService userDetailsService;
     @MockBean
     private AuthService authService;
+    @MockBean
+    private RateLimitingService rateLimitingService;
     @Autowired
     private MockMvc mockMvc;
+
+    @BeforeEach
+    void setup() {
+        MockUtils.disableRateLimiting(rateLimitingService);
+    }
 
     @Test
     void registerUserWhenThereArePreExistingUsers() throws Exception {
@@ -158,6 +168,14 @@ class AuthControllerTests {
     }
 
     @Test
+    @WithMockUser
+    void handlesRateLimitsReached() throws Exception {
+        MockUtils.mockRateLimitReached(rateLimitingService);
+        mockMvc.perform(utils.get(RoutesConfig.Auth.ME_PATH))
+                .andExpect(MockMvcResultMatchers.status().isTooManyRequests());
+    }
+
+    @Test
     void meRequestUnauthenticated() throws Exception {
         mockMvc.perform(utils.get(RoutesConfig.Auth.ME_PATH))
                 .andExpect(MockMvcResultMatchers.status().isForbidden());
@@ -193,7 +211,8 @@ class AuthControllerTests {
 
     @AfterEach
     void tearDown() {
-        Mockito.reset(mapper, encoder, usersRepository, userDetailsService, authService);
+        Mockito.reset(mapper, encoder, usersRepository, userDetailsService,
+                authService, rateLimitingService);
     }
 
 }

--- a/backend/src/test/java/com/ksonni/footballdb/users/UsersControllerTests.java
+++ b/backend/src/test/java/com/ksonni/footballdb/users/UsersControllerTests.java
@@ -3,6 +3,7 @@ package com.ksonni.footballdb.users;
 import com.ksonni.footballdb.config.RoutesConfig;
 import com.ksonni.footballdb.queryparser.Query;
 import com.ksonni.footballdb.queryparser.QueryParser;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
 import com.ksonni.footballdb.users.domain.Permission;
 import com.ksonni.footballdb.users.domain.Role;
 import com.ksonni.footballdb.users.domain.User;
@@ -10,6 +11,7 @@ import com.ksonni.footballdb.users.dto.UserResponse;
 import com.ksonni.footballdb.users.services.UsersMapper;
 import com.ksonni.footballdb.users.services.UsersRepository;
 import com.ksonni.footballdb.utils.MockMvcUtils;
+import com.ksonni.footballdb.utils.MockUtils;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.AfterEach;
@@ -44,6 +46,8 @@ public class UsersControllerTests {
     private UsersMapper usersMapper;
     @MockBean
     private QueryParser<User> queryParser;
+    @MockBean
+    private RateLimitingService rateLimitingService;
     @Autowired
     private MockMvc mockMvc;
     private List<User> users;
@@ -64,6 +68,7 @@ public class UsersControllerTests {
                 UserResponse.builder().id(user.getId()).emailId(user.getEmailId())
                         .role(user.getRole()).build()
         );
+        MockUtils.disableRateLimiting(rateLimitingService);
     }
 
     @Test
@@ -86,9 +91,18 @@ public class UsersControllerTests {
                 .andExpect(MockMvcResultMatchers.status().isForbidden());
     }
 
+    @Test
+    @WithMockUser(roles = {Permission.Code.VIEW_USERS})
+    void handlesRateLimitsReached() throws Exception {
+        MockUtils.mockRateLimitReached(rateLimitingService);
+        mockMvc.perform(utils.get(RoutesConfig.Users.PATH))
+                .andExpect(MockMvcResultMatchers.status().isTooManyRequests());
+    }
+
     @AfterEach
     void tearDown() {
-        Mockito.reset(userDetailsService, usersRepository, queryParser, usersMapper);
+        Mockito.reset(userDetailsService, usersRepository, queryParser,
+                usersMapper, rateLimitingService);
     }
 
 }

--- a/backend/src/test/java/com/ksonni/footballdb/utils/MockUtils.java
+++ b/backend/src/test/java/com/ksonni/footballdb/utils/MockUtils.java
@@ -1,0 +1,33 @@
+package com.ksonni.footballdb.utils;
+
+import com.ksonni.footballdb.ratelimiting.RateLimitingResult;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
+import org.mockito.ArgumentMatchers;
+import org.mockito.BDDMockito;
+
+public final class MockUtils {
+
+    private MockUtils() {
+    }
+
+    /**
+     * Makes the rate limiter to accept all requests for testing.
+     *
+     * @param rateLimitingService a mocked instance of the service
+     */
+    public static void disableRateLimiting(final RateLimitingService rateLimitingService) {
+        BDDMockito.given(rateLimitingService.evaluateRequest(ArgumentMatchers.any()))
+                .willReturn(RateLimitingResult.accept());
+    }
+
+    /**
+     * Mocks a condition where rate limits have been reached.
+     *
+     * @param rateLimitingService a mocked instance of the service.
+     */
+    public static void mockRateLimitReached(final RateLimitingService rateLimitingService) {
+        BDDMockito.given(rateLimitingService.evaluateRequest(ArgumentMatchers.any()))
+                .willReturn(RateLimitingResult.reject("Too many requests"));
+    }
+
+}


### PR DESCRIPTION
This uses the token bucket algorithm to limit request rate