### PR TITLE
GraphQL: enforce rate limits based on query complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,19 @@ query {
 
 Swagger UI docs for the management REST endpoints (these are authenticated APIs) can be found at: https://football-db.k-sonni.com/swagger-ui/index.html
 
+### Rate limiting
+
+[Token bucket](https://en.wikipedia.org/wiki/Token_bucket) algorithm is used to implement rate-limiting.
+
+- Has 60 tokens refreshing in a 3-minute window
+- For GraphQL, the number of tokens used per request depends on the complexity of the query
+- For the REST API, since the scope is fixed, it uses 1 token per request
+
 ## Technical overview
 
 - GraphQL API built with Java and Spring
   - The implementation of the query mechanism is in `app/src/main/.../query` and uses reflection to construct Spring Data specifications to execute queries
   - Code-generation is used to generate Java models from the GraphQL schema
-- Spring Security and [token bucket](https://en.wikipedia.org/wiki/Token_bucket) rate limiting to secure the application
 - Schema management with [Liquibase](https://www.liquibase.org/) to automate database migrations
 - Continuous Integration with GitHub Actions
 - Runs in a containerised docker-compose setup

--- a/app/src/main/java/com/ksonni/footballdb/config/AppConfig.java
+++ b/app/src/main/java/com/ksonni/footballdb/config/AppConfig.java
@@ -40,8 +40,8 @@ public class AppConfig {
 
     private final BuildProperties buildProperties;
 
-    @Value("${app.max-requests-per-window}")
-    private Integer maxRequestsPerWindow;
+    @Value("${app.max-requests-in-window}")
+    private Integer maxRequestsInWindow;
 
     @Value("${app.throttling-window-minutes}")
     private Integer throttlingWindowMinutes;
@@ -220,7 +220,7 @@ public class AppConfig {
     @Bean
     public RateLimitingService rateLimitingService() {
         return new IPRateLimitingService(
-            maxRequestsPerWindow,
+            maxRequestsInWindow,
             Duration.ofMinutes(throttlingWindowMinutes)
         );
     }

--- a/app/src/main/java/com/ksonni/footballdb/config/GraphQLConfig.java
+++ b/app/src/main/java/com/ksonni/footballdb/config/GraphQLConfig.java
@@ -1,12 +1,24 @@
 package com.ksonni.footballdb.config;
 
+import com.ksonni.footballdb.ratelimiting.QLRateLimitingInterceptor;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
+import graphql.analysis.MaxQueryComplexityInstrumentation;
+import graphql.execution.instrumentation.ChainedInstrumentation;
+import graphql.execution.instrumentation.Instrumentation;
 import graphql.scalars.ExtendedScalars;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.graphql.execution.RuntimeWiringConfigurer;
 
+import java.util.List;
+
 @Configuration
 public class GraphQLConfig {
+
+    @Value("${app.max-ql-complexity}")
+    private Integer maxQlComplexity;
+
     /**
      * Supports DateTime custom primitive in GraphQL types.
      * @return configurer
@@ -14,5 +26,19 @@ public class GraphQLConfig {
     @Bean
     public RuntimeWiringConfigurer runtimeWiringConfigurer() {
         return wiringBuilder -> wiringBuilder.scalar(ExtendedScalars.DateTime);
+    }
+
+    /**
+     * Returns a GraphQL instrumentation object that's used to enforce complexity & rate limits.
+     *
+     * @param rateLimitingService shared rate limits service
+     * @return Instrumentation
+     */
+    @Bean
+    public Instrumentation queryInstrumentation(final RateLimitingService rateLimitingService) {
+        return new ChainedInstrumentation(List.of(
+            new MaxQueryComplexityInstrumentation(maxQlComplexity),
+            new QLRateLimitingInterceptor(rateLimitingService)
+        ));
     }
 }

--- a/app/src/main/java/com/ksonni/footballdb/ratelimiting/QLRateLimitingInterceptor.java
+++ b/app/src/main/java/com/ksonni/footballdb/ratelimiting/QLRateLimitingInterceptor.java
@@ -1,0 +1,35 @@
+package com.ksonni.footballdb.ratelimiting;
+
+import graphql.ErrorType;
+import graphql.GraphqlErrorException;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.SimplePerformantInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationFieldFetchParameters;
+import graphql.schema.DataFetcher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class QLRateLimitingInterceptor extends SimplePerformantInstrumentation {
+    private final RateLimitingService rateLimitingService;
+
+    @Override
+    public DataFetcher<?> instrumentDataFetcher(
+        final DataFetcher<?> dataFetcher,
+        final InstrumentationFieldFetchParameters parameters,
+        final InstrumentationState state
+    ) {
+        if (parameters.isTrivialDataFetcher()) {
+            return dataFetcher;
+        }
+        final RateLimitingResult result = rateLimitingService.evaluateRequest();
+        if (!result.isAcceptable()) {
+            throw GraphqlErrorException.newErrorException()
+                .message(result.getRejectionReason())
+                .errorClassification(ErrorType.DataFetchingException)
+                .build();
+        }
+        return dataFetcher;
+    }
+}

--- a/app/src/main/java/com/ksonni/footballdb/ratelimiting/RateLimitingInterceptor.java
+++ b/app/src/main/java/com/ksonni/footballdb/ratelimiting/RateLimitingInterceptor.java
@@ -1,5 +1,6 @@
 package com.ksonni.footballdb.ratelimiting;
 
+import com.ksonni.footballdb.config.RoutesConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -20,6 +21,9 @@ public class RateLimitingInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
                              final Object handler) throws IOException {
+        if (request.getRequestURI().equals(RoutesConfig.GraphQL.PATH)) {
+            return true; // Handled by QLRateLimitingInterceptor
+        }
         final RateLimitingResult result = rateLimitingService.evaluateRequest(request);
         if (!result.isAcceptable()) {
             response.sendError(HttpStatus.TOO_MANY_REQUESTS.value(), result.getRejectionReason());

--- a/app/src/main/java/com/ksonni/footballdb/ratelimiting/RateLimitingService.java
+++ b/app/src/main/java/com/ksonni/footballdb/ratelimiting/RateLimitingService.java
@@ -1,5 +1,6 @@
 package com.ksonni.footballdb.ratelimiting;
 
+import com.ksonni.footballdb.utils.HttpUtils;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface RateLimitingService {
@@ -11,5 +12,15 @@ public interface RateLimitingService {
      * @return Result indicating if a request can be accepted
      */
     RateLimitingResult evaluateRequest(HttpServletRequest request);
+
+    /**
+     * Helper that determines the current request before applying the rate limiting strategy.
+     *
+     * @return Result indicating if a request can be accepted
+     */
+    default RateLimitingResult evaluateRequest() {
+        return HttpUtils.getCurrentRequest().map(this::evaluateRequest)
+            .orElse(RateLimitingResult.reject("Failed to find request context"));
+    }
 
 }

--- a/app/src/main/java/com/ksonni/footballdb/utils/HttpUtils.java
+++ b/app/src/main/java/com/ksonni/footballdb/utils/HttpUtils.java
@@ -1,17 +1,21 @@
 package com.ksonni.footballdb.utils;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 
 public final class HttpUtils {
 
     private HttpUtils() {
     }
 
-    public static HttpServletRequest getCurrentRequest() {
-        return ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
+    public static Optional<HttpServletRequest> getCurrentRequest() {
+        return Optional.ofNullable(RequestContextHolder.getRequestAttributes())
+            .filter(ServletRequestAttributes.class::isInstance)
+            .map(ServletRequestAttributes.class::cast)
+            .map(ServletRequestAttributes::getRequest);
     }
 
 }

--- a/app/src/main/java/com/ksonni/footballdb/validation/ErrorResponse.java
+++ b/app/src/main/java/com/ksonni/footballdb/validation/ErrorResponse.java
@@ -6,7 +6,6 @@ import com.ksonni.footballdb.utils.HttpUtils;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -44,8 +43,9 @@ public class ErrorResponse {
     }
 
     private String getRequestPath() {
-        final HttpServletRequest request = HttpUtils.getCurrentRequest();
-        return request.getRequestURI().substring(request.getContextPath().length());
+        return HttpUtils.getCurrentRequest()
+            .map(r -> r.getRequestURI().substring(r.getContextPath().length()))
+            .orElse("");
     }
 
 }

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -1,9 +1,10 @@
 # App
-app.max-requests-per-window=60
+app.max-requests-in-window=60
 app.throttling-window-minutes=3
-app.max-filter-components=10
+app.max-filter-components=20
 app.max-sort-components=5
 app.max-results-per-page=100
+app.max-ql-complexity=80
 app.files-path=/data/files/
 app.file-size-limit-bytes=512000
 

--- a/app/src/test/java/com/ksonni/footballdb/clubs/ClubsControllerQLTest.java
+++ b/app/src/test/java/com/ksonni/footballdb/clubs/ClubsControllerQLTest.java
@@ -10,8 +10,11 @@ import com.ksonni.footballdb.generated.ql.QLClubSort;
 import com.ksonni.footballdb.query.FilterParser;
 import com.ksonni.footballdb.query.PageResult;
 import com.ksonni.footballdb.query.SortParser;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
+import com.ksonni.footballdb.utils.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
@@ -35,6 +38,15 @@ class ClubsControllerQLTest {
     private FilterParser<Club, QLClubFilter> clubsFilterParser;
     @MockitoBean
     private SortParser<QLClubSort> clubsSortParser;
+    @MockitoBean
+    private RateLimitingService rateLimitingService;
+
+    private final String clubsQuery = "query { clubs { content { id name } } }";
+
+    @BeforeEach
+    void setup() {
+        TestUtils.disableRateLimiting(rateLimitingService);
+    }
 
     @Test
     void testClubsPath() {
@@ -48,7 +60,7 @@ class ClubsControllerQLTest {
 
         // Execute
         final var contentPath = "clubs.content";
-        final var response = graphQlTester.document("query { clubs { content { id name } } }")
+        final var response = graphQlTester.document(clubsQuery)
             .execute().path(contentPath).entityList(QLClub.class).get();
 
         // Verify
@@ -74,8 +86,20 @@ class ClubsControllerQLTest {
         Assertions.assertEquals(club.getName(), response.getName());
     }
 
+    @Test
+    void testEnforcesRateLimits() {
+        // Setup
+        TestUtils.mockRateLimitReached(rateLimitingService);
+
+        // Execute
+        graphQlTester.document(clubsQuery)
+            .execute().errors()
+            .expect(e -> e.getErrorType().equals(graphql.ErrorType.DataFetchingException)).verify()
+            .path("clubs").pathDoesNotExist();
+    }
+
     @AfterEach
     void tearDown() {
-        Mockito.reset(clubsRepository, clubsFilterParser, clubsSortParser);
+        Mockito.reset(clubsRepository, clubsFilterParser, clubsSortParser, rateLimitingService);
     }
 }

--- a/app/src/test/java/com/ksonni/footballdb/files/FilesControllerQLTest.java
+++ b/app/src/test/java/com/ksonni/footballdb/files/FilesControllerQLTest.java
@@ -10,8 +10,11 @@ import com.ksonni.footballdb.generated.ql.QLFileRegistrationSort;
 import com.ksonni.footballdb.query.FilterParser;
 import com.ksonni.footballdb.query.PageResult;
 import com.ksonni.footballdb.query.SortParser;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
+import com.ksonni.footballdb.utils.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
@@ -34,6 +37,15 @@ class FilesControllerQLTest {
     private FilterParser<FileRegistration, QLFileRegistrationFilter> filesFilterParser;
     @MockitoBean
     private SortParser<QLFileRegistrationSort> filesSortParser;
+    @MockitoBean
+    private RateLimitingService rateLimitingService;
+
+    private final String filesQuery = "query { files { content { id name } } }";
+
+    @BeforeEach
+    void setup() {
+        TestUtils.disableRateLimiting(rateLimitingService);
+    }
 
     @Test
     void testFilesPath() {
@@ -47,7 +59,7 @@ class FilesControllerQLTest {
 
         // Execute
         final var contentPath = "files.content";
-        final var response = graphQlTester.document("query { files { content { id name } } }")
+        final var response = graphQlTester.document(filesQuery)
             .execute().path(contentPath).entityList(QLFileRegistration.class).get();
 
         // Verify
@@ -58,8 +70,20 @@ class FilesControllerQLTest {
         }
     }
 
+    @Test
+    void testEnforcesRateLimits() {
+        // Setup
+        TestUtils.mockRateLimitReached(rateLimitingService);
+
+        // Execute
+        graphQlTester.document(filesQuery)
+            .execute().errors()
+            .expect(e -> e.getErrorType().equals(graphql.ErrorType.DataFetchingException)).verify()
+            .path("files").pathDoesNotExist();
+    }
+
     @AfterEach
     void tearDown() {
-        Mockito.reset(filesRepository, filesFilterParser, filesSortParser);
+        Mockito.reset(filesRepository, filesFilterParser, filesSortParser, rateLimitingService);
     }
 }

--- a/app/src/test/java/com/ksonni/footballdb/leagues/LeaguesControllerQLTest.java
+++ b/app/src/test/java/com/ksonni/footballdb/leagues/LeaguesControllerQLTest.java
@@ -10,8 +10,11 @@ import com.ksonni.footballdb.leagues.services.LeaguesRepository;
 import com.ksonni.footballdb.query.FilterParser;
 import com.ksonni.footballdb.query.PageResult;
 import com.ksonni.footballdb.query.SortParser;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
+import com.ksonni.footballdb.utils.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
@@ -35,6 +38,16 @@ class LeaguesControllerQLTest {
     private FilterParser<League, QLLeagueFilter> leaguesFilterParser;
     @MockitoBean
     private SortParser<QLLeagueSort> leaguesSortParser;
+    @MockitoBean
+    private RateLimitingService rateLimitingService;
+
+    private final String leaguesPath = "leagues";
+    private final String leaguesQuery = "query { leagues { content { id name } } }";
+
+    @BeforeEach
+    void setup() {
+        TestUtils.disableRateLimiting(rateLimitingService);
+    }
 
     @Test
     void testLeaguesPath() {
@@ -48,7 +61,7 @@ class LeaguesControllerQLTest {
 
         // Execute
         final var contentPath = "leagues.content";
-        final var response = graphQlTester.document("query { leagues { content { id name } } }")
+        final var response = graphQlTester.document(leaguesQuery)
             .execute().path(contentPath).entityList(QLLeague.class).get();
 
         // Verify
@@ -74,8 +87,20 @@ class LeaguesControllerQLTest {
         Assertions.assertEquals(league.getName(), response.getName());
     }
 
+    @Test
+    void testEnforcesRateLimits() {
+        // Setup
+        TestUtils.mockRateLimitReached(rateLimitingService);
+
+        // Execute
+        graphQlTester.document(leaguesQuery)
+            .execute().errors()
+            .expect(e -> e.getErrorType().equals(graphql.ErrorType.DataFetchingException)).verify()
+            .path(leaguesPath).pathDoesNotExist();
+    }
+
     @AfterEach
     void tearDown() {
-        Mockito.reset(leaguesRepository, leaguesFilterParser, leaguesSortParser);
+        Mockito.reset(leaguesRepository, leaguesFilterParser, leaguesSortParser, rateLimitingService);
     }
 }

--- a/app/src/test/java/com/ksonni/footballdb/players/PlayersControllerQLTest.java
+++ b/app/src/test/java/com/ksonni/footballdb/players/PlayersControllerQLTest.java
@@ -12,8 +12,11 @@ import com.ksonni.footballdb.query.FilterParseException;
 import com.ksonni.footballdb.query.FilterParser;
 import com.ksonni.footballdb.query.PageResult;
 import com.ksonni.footballdb.query.SortParser;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
+import com.ksonni.footballdb.utils.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
@@ -37,10 +40,17 @@ public class PlayersControllerQLTest {
     @MockitoBean
     private FilterParser<Player, QLPlayerFilter> playersFilterParser;
     @MockitoBean
+    private RateLimitingService rateLimitingService;
+    @MockitoBean
     private SortParser<QLPlayerSort> playersSortParser;
 
     private final String playersPath = "players";
     private final String playersQuery = "query { players { content { id fullName } } }";
+
+    @BeforeEach
+    void setup() {
+        TestUtils.disableRateLimiting(rateLimitingService);
+    }
 
     @Test
     void testPlayersPath() {
@@ -108,8 +118,20 @@ public class PlayersControllerQLTest {
         Assertions.assertEquals(player.getFullName(), response.getFullName());
     }
 
+    @Test
+    void testEnforcesRateLimits() {
+        // Setup
+        TestUtils.mockRateLimitReached(rateLimitingService);
+
+        // Execute
+        graphQlTester.document(playersQuery)
+            .execute().errors()
+            .expect(e -> e.getErrorType().equals(graphql.ErrorType.DataFetchingException)).verify()
+            .path(playersPath).pathDoesNotExist();
+    }
+
     @AfterEach
     void tearDown() {
-        Mockito.reset(playersRepository, playersFilterParser, playersSortParser);
+        Mockito.reset(playersRepository, playersFilterParser, playersSortParser, rateLimitingService);
     }
 }

--- a/app/src/test/java/com/ksonni/footballdb/users/UsersControllerQLTest.java
+++ b/app/src/test/java/com/ksonni/footballdb/users/UsersControllerQLTest.java
@@ -7,11 +7,14 @@ import com.ksonni.footballdb.generated.ql.QLUserSort;
 import com.ksonni.footballdb.query.FilterParser;
 import com.ksonni.footballdb.query.PageResult;
 import com.ksonni.footballdb.query.SortParser;
+import com.ksonni.footballdb.ratelimiting.RateLimitingService;
 import com.ksonni.footballdb.users.domain.User;
 import com.ksonni.footballdb.users.services.UsersMapperImpl;
 import com.ksonni.footballdb.users.services.UsersRepository;
+import com.ksonni.footballdb.utils.TestUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
@@ -35,6 +38,15 @@ class UsersControllerQLTest {
     private FilterParser<User, QLUserFilter> usersFilterParser;
     @MockitoBean
     private SortParser<QLUserSort> usersSortParser;
+    @MockitoBean
+    private RateLimitingService rateLimitingService;
+
+    private final String usersQuery = "query { users { content { id emailId } } }";
+
+    @BeforeEach
+    void setup() {
+        TestUtils.disableRateLimiting(rateLimitingService);
+    }
 
     @Test
     void testUsersPath() {
@@ -48,7 +60,7 @@ class UsersControllerQLTest {
 
         // Execute
         final var contentPath = "users.content";
-        final var response = graphQlTester.document("query { users { content { id emailId } } }")
+        final var response = graphQlTester.document(usersQuery)
             .execute().path(contentPath).entityList(QLUser.class).get();
 
         // Verify
@@ -74,8 +86,20 @@ class UsersControllerQLTest {
         Assertions.assertEquals(user.getEmailId(), response.getEmailId());
     }
 
+    @Test
+    void testEnforcesRateLimits() {
+        // Setup
+        TestUtils.mockRateLimitReached(rateLimitingService);
+
+        // Execute
+        graphQlTester.document(usersQuery)
+            .execute().errors()
+            .expect(e -> e.getErrorType().equals(graphql.ErrorType.DataFetchingException)).verify()
+            .path("users").pathDoesNotExist();
+    }
+
     @AfterEach
     void tearDown() {
-        Mockito.reset(usersRepository, usersFilterParser, usersSortParser);
+        Mockito.reset(usersRepository, usersFilterParser, usersSortParser, rateLimitingService);
     }
 }

--- a/app/src/test/java/com/ksonni/footballdb/utils/TestUtils.java
+++ b/app/src/test/java/com/ksonni/footballdb/utils/TestUtils.java
@@ -23,6 +23,8 @@ public final class TestUtils {
     public static void disableRateLimiting(final RateLimitingService rateLimitingService) {
         BDDMockito.given(rateLimitingService.evaluateRequest(ArgumentMatchers.any()))
                 .willReturn(RateLimitingResult.accept());
+        BDDMockito.given(rateLimitingService.evaluateRequest())
+            .willReturn(RateLimitingResult.accept());
     }
 
     /**
@@ -31,8 +33,11 @@ public final class TestUtils {
      * @param rateLimitingService a mocked instance of the service.
      */
     public static void mockRateLimitReached(final RateLimitingService rateLimitingService) {
+        final var rejection = RateLimitingResult.reject("Too many requests");
         BDDMockito.given(rateLimitingService.evaluateRequest(ArgumentMatchers.any()))
-                .willReturn(RateLimitingResult.reject("Too many requests"));
+                .willReturn(rejection);
+        BDDMockito.given(rateLimitingService.evaluateRequest())
+            .willReturn(rejection);
     }
 
     /**


### PR DESCRIPTION
Now every non-trivial resolver costs 1 additional token